### PR TITLE
Use Github Actions to build Multi-Arch OpenFaaS hugo functions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,59 @@
+name: CI/CD
+
+on:
+  push:
+    branches: 
+      - master
+jobs:
+  func-build:
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Define ENV VARS
+        id: define_env
+        run:  echo "::set-output name=github-sha-short::$(echo $GITHUB_SHA | cut -c 1-7)"
+      -
+        name: Pull template
+        uses: docker://openfaas/faas-cli:latest-root
+        with:
+          args: template pull https://github.com/utsavanand2/openfaas-hugo-template
+      - 
+        name: Add theme submodule
+        run: git submodule add -f https://github.com/budparr/gohugo-theme-ananke.git hello-multi-arch/themes/ananke
+      - 
+        name: Run shrinkwrap build
+        uses: docker://openfaas/faas-cli:latest-root
+        with:
+          args: build -f kubecon-multi-arch-blog.yml --shrinkwrap
+      -
+        name: Login to OpenFaaS Gateway
+        uses: docker://openfaas/faas-cli:latest-root
+        with:
+          args: login -p ${{ secrets.OPENFAAS_GATEWAY_PASSWD }} \
+                      -g ${{ secrets.OPENFAAS_GATEWAY }}
+      -
+        name: Login to DockerHub
+        if: success()
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - 
+        name: Build and Push the OpenFaaS function
+        uses: docker/build-push-action@v2
+        with:
+          context: ./build/kubecon-multi-arch-blog/
+          file: ./build/kubecon-multi-arch-blog/Dockerfile
+          push: true
+          tags: alexellis2/kubecon-multi-arch-blog:latest-${{ steps.define_env.outputs.github-sha-short }}
+      - 
+        name: Deploy the function
+        uses: docker://openfaas/faas-cli:latest-root
+        with:
+          args: deploy -f kubecon-multi-arch-blog.yml --tag sha  

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+template
+build
+kubecon-multi-arch-blog/themes

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "kubecon-multi-arch-blog/themes/ananke"]
+	path = kubecon-multi-arch-blog/themes/ananke
+	url = https://github.com/budparr/gohugo-theme-ananke.git

--- a/README.md
+++ b/README.md
@@ -1,2 +1,50 @@
 # kubecon-blog
 My blog about my KubeCon talk, also my demo
+
+You would need to change the file `kubecon-multi-arch-blog.yml` to point to the gateway of your OpenFaaS deployment.
+
+
+General overview of the steps to make this run locally which can be mapped to Github Actions:
+
+```bash
+# Pull templates
+faas-cli template pull https://github.com/utsavanand2/openfaas-hugo-template
+
+# Create new function (not required in github actions)
+faas-cli new kubecon-multi-arch-blog --lang hugo --prefix alexellis2
+
+# cd into kubecon-multi-arch-blog (not required in github actions)
+cd kubecon-multi-arch-blog
+
+# Create a new site (not required in github actions)
+hugo new site .
+
+# IMPORTANT. Make sure to change the base URL in config.toml 
+# from-> baseURL = "http://example.org/"
+# to-> baseURL = "http://$IP:8080/function/kubecon-multi-arch-blog/"
+
+# Pull the hugo theme (this cmd is run with a slight modification in github actions)
+git submodule add https://github.com/budparr/gohugo-theme-ananke.git themes/ananke && \
+echo 'theme = "ananke"' >> config.toml
+
+# Create a new post (not required in github actions)
+hugo new posts/my-blog-is-serverless-and-multi-arch.md
+
+# cd back into the root of the project dir (not required in github actions)
+cd ..
+
+# Add the themes dir to .gitignore because it causes trouble in Github Actions
+echo kubecon-multi-arch-blog/themes >> .gitignore
+
+# Run shrinkwrap build
+faas-cli build -f kubecon-multi-arch-blog.yml --shrinkwrap
+
+# Build with Docker Buildx (this cmd is run with a slight modification in github actions)
+docker buildx build --platform linux/amd64,linux/arm64 --output "type=image,push=true" -t alexellis2/kubecon-multi-arch-blog:latest --no-cache build/kubecon-multi-arch-blog/
+
+# Deploy to OpenFaaS (this cmd is run with a slight modification in github actions)
+faas-cli deploy -f kubecon-multi-arch-blog.yml
+
+# Let's Thank Matias for his awesome blog post! Made our lives so much easy!
+https://www.openfaas.com/blog/serverless-static-sites/
+```

--- a/kubecon-multi-arch-blog.yml
+++ b/kubecon-multi-arch-blog.yml
@@ -1,0 +1,10 @@
+version: 1.0
+provider:
+  name: openfaas
+  gateway: https://openfaas.kumarutsavanand.com
+functions:
+  kubecon-multi-arch-blog:
+    lang: hugo
+    handler: ./kubecon-multi-arch-blog
+    image: alexellis2/kubecon-multi-arch-blog:latest
+

--- a/kubecon-multi-arch-blog/archetypes/default.md
+++ b/kubecon-multi-arch-blog/archetypes/default.md
@@ -1,0 +1,6 @@
+---
+title: "{{ replace .Name "-" " " | title }}"
+date: {{ .Date }}
+draft: true
+---
+

--- a/kubecon-multi-arch-blog/config.toml
+++ b/kubecon-multi-arch-blog/config.toml
@@ -1,0 +1,4 @@
+baseURL = "http://example.org/"
+languageCode = "en-us"
+title = "My New Hugo Site"
+theme = "ananke"


### PR DESCRIPTION
General overview of the steps to make this run locally which can be mapped to Github Actions:

```bash
# Pull templates
faas-cli template pull https://github.com/utsavanand2/openfaas-hugo-template

# Create new function (not required in github actions)
faas-cli new kubecon-multi-arch-blog --lang hugo --prefix alexellis2

# cd into kubecon-multi-arch-blog (not required in github actions)
cd kubecon-multi-arch-blog

# Create a new site (not required in github actions)
hugo new site .

# IMPORTANT. Make sure to change the base URL in config.toml
# from-> baseURL = "http://example.org/"
# to-> baseURL = "http://$IP:8080/function/kubecon-multi-arch-blog/"

# Pull the hugo theme (this cmd is run with a slight modification in github actions)
git submodule add https://github.com/budparr/gohugo-theme-ananke.git themes/ananke && \
echo 'theme = "ananke"' >> config.toml

# Create a new post (not required in github actions)
hugo new posts/my-blog-is-serverless-and-multi-arch.md

# cd back into the root of the project dir (not required in github actions)
cd ..

# Add the themes dir to .gitignore because it causes trouble in Github Actions
echo kubecon-multi-arch-blog/themes >> .gitignore

# Run shrinkwrap build
faas-cli build -f kubecon-multi-arch-blog.yml --shrinkwrap

# Build with Docker Buildx (this cmd is run with a slight modification in github actions)
docker buildx build --platform linux/amd64,linux/arm64 --output "type=image,push=true" -t alexellis2/kubecon-multi-arch-blog:latest --no-cache build/kubecon-multi-arch-blog/

# Deploy to OpenFaaS (this cmd is run with a slight modification in github actions)
faas-cli deploy -f kubecon-multi-arch-blog.yml

# Let's Thank Matias for his awesome blog post! Made our lives so much easy!
https://www.openfaas.com/blog/serverless-static-sites/